### PR TITLE
FEAT: swan.json file at root of parties' web site contains party details and privacy policy URL.

### DIFF
--- a/src/common/handlerStatic.go
+++ b/src/common/handlerStatic.go
@@ -23,6 +23,11 @@ import (
 	"strings"
 )
 
+// Map of allowed static files and whether request for file should support CORS
+var allowList = map[string]bool{
+	"swan.json": true,
+}
+
 // handlerStatic locates and returns static content if relevant to the HTTP
 // request. True is returned if static content was returned, otherwise false.
 func handlerStatic(
@@ -112,6 +117,14 @@ func handlerFile(
 	case ".map":
 		http.ServeFile(w, r, f)
 		return true
+	default:
+		if c, ok := allowList[filepath.Base(f)]; ok {
+			if c {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			}
+			http.ServeFile(w, r, f)
+			return true
+		}
+		return false
 	}
-	return false
 }

--- a/www/badssp.swan-demo.uk/swan.json
+++ b/www/badssp.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/bidswitch.swan-demo.uk/swan.json
+++ b/www/bidswitch.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/centro.swan-demo.uk/swan.json
+++ b/www/centro.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/cmp.swan-demo.uk/swan.json
+++ b/www/cmp.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/cool-bikes.uk/swan.json
+++ b/www/cool-bikes.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/cool-cars.uk/swan.json
+++ b/www/cool-cars.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/cool-creams.uk/swan.json
+++ b/www/cool-creams.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/current-bun.uk/swan.json
+++ b/www/current-bun.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/dataxu.swan-demo.uk/swan.json
+++ b/www/dataxu.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/liveintent.swan-demo.uk/swan.json
+++ b/www/liveintent.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/liveramp.swan-demo.uk/swan.json
+++ b/www/liveramp.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/magnite.swan-demo.uk/swan.json
+++ b/www/magnite.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/mediamath.swan-demo.uk/swan.json
+++ b/www/mediamath.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/new-pork-limes.uk/swan.json
+++ b/www/new-pork-limes.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/oath.swan-demo.uk/swan.json
+++ b/www/oath.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/pop-up.swan-demo.uk/swan.json
+++ b/www/pop-up.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/pub.bln.liveintent.com/swan.json
+++ b/www/pub.bln.liveintent.com/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/pubmatic.swan-demo.uk/swan.json
+++ b/www/pubmatic.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/quantcast.swan-demo.uk/swan.json
+++ b/www/quantcast.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/smaato.swan-demo.uk/swan.json
+++ b/www/smaato.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/swan-demo.uk/swan.json
+++ b/www/swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/swanson.bln.liveintent.com/swan.json
+++ b/www/swanson.bln.liveintent.com/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/thetradedesk.swan-demo.uk/swan.json
+++ b/www/thetradedesk.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}

--- a/www/zeta.swan-demo.uk/swan.json
+++ b/www/zeta.swan-demo.uk/swan.json
@@ -1,0 +1,4 @@
+{
+    "description": "Fusce ex neque, faucibus ac mauris ut, tincidunt fermentum lectus. Nam sollicitudin dui placerat, vestibulum ex sed, ultricies purus. Nulla consequat, magna ac dapibus dapibus, arcu nisl sollicitudin libero, ac mollis lacus quam ac nunc. Aliquam nec massa eu arcu dapibus dignissim. Nullam accumsan risus et libero aliquet finibus.",
+    "privacyPolicyUrl": "/privacy-policy.html"
+}


### PR DESCRIPTION
Add allow list to static file handler to check if file does not match any of the allowed files extensions. The motivation behind this is to expose certain files without making all files with the same extension available e.g. config.json.